### PR TITLE
Revert "add back ruff fix and organize imports"

### DIFF
--- a/lua/kickstart/plugins/conform.lua
+++ b/lua/kickstart/plugins/conform.lua
@@ -70,9 +70,7 @@ return {
         lua = { 'stylua' },
         -- use ruff as formatter, conform with 'ruff_format' uses ruff binary and ignores server settings/configs
         -- https://github.com/astral-sh/ruff/issues/12778
-        -- currently ruff_organize_imports uses linter rather than formater, a unified interface is planned
-        -- https://github.com/astral-sh/ruff/issues/8232
-        python = { 'ruff_fix', 'ruff_organize_imports', lsp_format = 'first' }, -- force confom to use ruff lsp server
+        python = { lsp_format = 'first' }, -- force confom to use ruff lsp server
         sql = { 'sqlfluff' },
         markdown = { 'prettier', 'markdown-toc', 'markdownlint-cli2' },
         -- Conform can also run multiple formatters sequentially


### PR DESCRIPTION
Reverts SafetyMary/neovim_config#9

Will organize imports but breaks ruff formatting